### PR TITLE
Fix teacache forward arg handling

### DIFF
--- a/model_patcher/teacache.py
+++ b/model_patcher/teacache.py
@@ -105,6 +105,7 @@ def teacache_wanmodel_forward(
         context,
         clip_fea=None,
         freqs=None,
+        control=None,
         transformer_options={},
         **kwargs,
     ):


### PR DESCRIPTION
## Summary
- ensure `teacache_wanmodel_forward` accepts the `control` parameter

## Testing
- `pytest -q` *(fails: command not found)*