### PR TITLE
Expose TeaCache threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ Search for flow2-wan-video in the Comfyui manager custom node list and click Ins
 3. Go to `ComfyUI_windows_portable/` folder and Run command to
 `python_embeded\python.exe -m pip install -r "ComfyUI\custom_nodes\flow2-wan-video\requirements.txt"`
 Done.
+
+### Custom threshold
+The **Wan Model Patcher** node now accepts an optional `teacache_rel_l1_thresh` value.
+Set this to override the TeaCache relative L1 distance threshold; use `0` for the built-in default of `0.2`.

--- a/custom_nodes.py
+++ b/custom_nodes.py
@@ -388,6 +388,15 @@ class WanVideoModelPatcher_F2:
                 "patch": ("PATCH", ),
                 "sage_attention": (("disabled", "auto", "triton", ), ),
                 "teacache": (("disabled", "normal", "retention", ), ),
+                "teacache_rel_l1_thresh": ("FLOAT", {
+                    "default": 0.2,
+                    "min": 0.0,
+                    "max": 1.0,
+                    "step": 0.01,
+                    "round": 0.01,
+                    "tooltip": "Override TeaCache threshold; 0 uses default.",
+                    "advanced": True,
+                }),
                 "compile_model": (("disabled", "default", ), ),
             }
         }
@@ -405,6 +414,7 @@ class WanVideoModelPatcher_F2:
             sage_attention,
             teacache,
             compile_model,
+            teacache_rel_l1_thresh,
         ):
 
         if not patch:
@@ -442,7 +452,13 @@ class WanVideoModelPatcher_F2:
             model = patch_cfg_zero_star(model, int(config.cfg_zero_steps))
 
         if teacache != "disabled":
-            model = patch_teacache(model, WanVideoModelLoader_F2.loaded_model[0], teacache)
+            rel_thresh = None if teacache_rel_l1_thresh <= 0 else teacache_rel_l1_thresh
+            model = patch_teacache(
+                model,
+                WanVideoModelLoader_F2.loaded_model[0],
+                teacache,
+                rel_thresh
+            )
 
         if compile_model != "disabled":
             model = torch_compile_model(model, compile_model)

--- a/examples/fun_inpaint_start_end.json
+++ b/examples/fun_inpaint_start_end.json
@@ -544,6 +544,7 @@
       "widgets_values": [
         "disabled",
         "disabled",
+        0.2,
         "disabled"
       ],
       "color": "#323",

--- a/examples/workflow_example_i2v.json
+++ b/examples/workflow_example_i2v.json
@@ -182,6 +182,7 @@
       "widgets_values": [
         "triton",
         "retention",
+        0.2,
         "disabled"
       ],
       "color": "#323",

--- a/examples/workflow_example_t2v.json
+++ b/examples/workflow_example_t2v.json
@@ -249,6 +249,7 @@
       "widgets_values": [
         "triton",
         "retention",
+        0.2,
         "disabled"
       ],
       "color": "#323",

--- a/model_patcher/teacache.py
+++ b/model_patcher/teacache.py
@@ -26,7 +26,7 @@ WEIGHT_480P = -4.353462645667605e-05
 
 offload_device = mm.unet_offload_device()
 
-def patch_teacache(model, model_name, mode):
+def patch_teacache(model, model_name, mode, rel_l1_thresh=None):
     model_type = None
     if all(k in model_name for k in ("i2v", "14b", "720p")):
         model_type = "i2v_720p_14B"
@@ -47,9 +47,13 @@ def patch_teacache(model, model_name, mode):
     new_model = model.clone()
     
     coefficients = SUPPORTED_MODELS_COEFFICIENTS[mode][model_type][0]
-    rel_l1_thresh = SUPPORTED_MODELS_COEFFICIENTS[mode][model_type][1]
+    default_rel_l1_thresh = SUPPORTED_MODELS_COEFFICIENTS[mode][model_type][1]
+    if rel_l1_thresh is None or rel_l1_thresh <= 0:
+        rel_l1_thresh = default_rel_l1_thresh
 
-    print(f"patched teacache mode: {mode}, model_type: {model_type}, rel_l1_thresh: {rel_l1_thresh}")
+    print(
+        f"patched teacache mode: {mode}, model_type: {model_type}, rel_l1_thresh: {rel_l1_thresh}"
+    )
 
     if 'transformer_options' not in new_model.model_options:
         new_model.model_options['transformer_options'] = {}    


### PR DESCRIPTION
## Summary
- add optional rel_l1_thresh override support in TeaCache patcher
- surface parameter `teacache_rel_l1_thresh` in Wan Model Patcher node
- use 0.2 as the default threshold value
- update example workflows
- document new option in README

## Testing
- `python -m py_compile model_patcher/teacache.py custom_nodes.py`
