### PR TITLE
Add AI prompt rephrasing node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,6 +12,7 @@ NODE_CLASS_MAPPINGS = {
     "WanVideoSampler_F2"            : WanVideoSampler_F2,
     "WanVideoEnhancer_F2"           : WanVideoEnhancer_F2,
     "ResizeImage_F2"                : ResizeImage_F2,
+    "AIPromptRephrasing"           : AIPromptRephrasing,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -22,4 +23,5 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "WanVideoSampler_F2"            : "Wan Sampler",
     "WanVideoEnhancer_F2"           : "Wan Frame Enhancer",
     "ResizeImage_F2"                : "Resize Image",
+    "AIPromptRephrasing"           : "AI Prompt Rephrasing",
 }


### PR DESCRIPTION
## Summary
- add `AIPromptRephrasing` node to rephrase prompts via OpenAI compatible API
- register the node in `__init__.py`
- extract model choices from the API's `/models` endpoint

## Testing
- `pytest -q`
