### PR TITLE
Fix models cache reference

### DIFF
--- a/custom_nodes.py
+++ b/custom_nodes.py
@@ -1291,7 +1291,7 @@ class AIPromptRephrasing:
             model = models[0]
 
         # refresh available models for the provided URL
-        models = self.MODELS_BY_URL.get(url)
+        models = self._models_cache.get(url)
         if models is None:
             models = self.fetch_models(url)
         if model not in models:


### PR DESCRIPTION
## Summary
- fix broken variable name when looking up cached models

## Testing
- `python -m py_compile custom_nodes.py`